### PR TITLE
Use custom query for app settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Use custom query for app settings
+
 ## [0.6.0] - 2023-03-03
 
 ### Changed

--- a/react/Admin.tsx
+++ b/react/Admin.tsx
@@ -120,11 +120,24 @@ const Admin: FC = () => {
   }
 
   useEffect(() => {
-    if (!data?.publicSettingsForApp?.message) return
-
-    const parsedSettings: any = JSON.parse(data.publicSettingsForApp.message)
-
-    setSettingsState(parsedSettings)
+    if (!data?.getAppSettings) return
+    
+    setSettingsState({
+      ...settingsState,
+      CustomNsu: data.getAppSettings.customNsu,
+      EnableTax: data.getAppSettings.enableTax,
+      EnableTransactionPosting: data.getAppSettings.enableTrasactionPosting,
+      IsLive: data.getAppSettings.isLive,
+      MerchantId: data.getAppSettings.merchantId,
+      MerchantKey: data.getAppSettings.merchantKey,
+      NexusRegions: data.getAppSettings.nexusRegions,
+      OrderSuffix: data.getAppSettings.orderSuffix,
+      Processor: data.getAppSettings.processor,
+      Region: data.getAppSettings.region,
+      SalesChannelExclude: data.getAppSettings.salesChannelExclude,
+      SharedSecretKey: data.getAppSettings.sharedSecretKey,
+      ShippingProductCode: data.getAppSettings.shippingProductCode
+    })
   }, [data])
 
   if (!data) {

--- a/react/Admin.tsx
+++ b/react/Admin.tsx
@@ -121,7 +121,7 @@ const Admin: FC = () => {
 
   useEffect(() => {
     if (!data?.getAppSettings) return
-    
+
     setSettingsState({
       ...settingsState,
       CustomNsu: data.getAppSettings.customNsu,
@@ -136,7 +136,7 @@ const Admin: FC = () => {
       Region: data.getAppSettings.region,
       SalesChannelExclude: data.getAppSettings.salesChannelExclude,
       SharedSecretKey: data.getAppSettings.sharedSecretKey,
-      ShippingProductCode: data.getAppSettings.shippingProductCode
+      ShippingProductCode: data.getAppSettings.shippingProductCode,
     })
   }, [data])
 

--- a/react/queries/appSettings.gql
+++ b/react/queries/appSettings.gql
@@ -1,6 +1,17 @@
 query AppSettings($version: String) {
-  publicSettingsForApp(app: "vtex.cybersource-ui", version: $version)
-    @context(provider: "vtex.apps-graphql") {
-    message
+  getAppSettings{
+    isLive
+    merchantId
+    merchantKey
+    sharedSecretKey
+    processor
+    region
+    orderSuffix
+    customNsu
+    enableTax
+    enableTransactionPosting
+    salesChannelExclude
+    shippingProductCode
+    nexusRegions
   }
 }


### PR DESCRIPTION
The new `publicSettingsForApp` query does not work. Added query to retrieve app settings.